### PR TITLE
Read/write access callbacks

### DIFF
--- a/pyca/pyca.cc
+++ b/pyca/pyca.cc
@@ -135,6 +135,17 @@ extern "C" {
         return ok();
     }
 
+    static PyObject* replace_access_rights_event(PyObject* self, PyObject* args)
+    {
+        capv* pv = reinterpret_cast<capv*>(self);
+        chid cid = pv->cid;
+        int result = ca_replace_access_rights_event(cid, pyca_access_rights_handler);
+        if (result != ECA_NORMAL) {
+            pyca_raise_caexc_pv("replace_access_rights_event", result, pv);
+        }
+        return ok();
+    }
+
     static PyObject* get_enum_strings(PyObject* self, PyObject* args)
     {
         capv* pv = reinterpret_cast<capv*>(self);
@@ -409,6 +420,7 @@ extern "C" {
         pv->processor = 0;
         pv->connect_cb = 0;
         pv->monitor_cb = 0;
+        pv->rwaccess_cb = 0;
         pv->getevt_cb = 0;
         pv->putevt_cb = 0;
         pv->simulated = Py_None;
@@ -479,6 +491,7 @@ extern "C" {
         {"count", count, METH_VARARGS},
         {"type", type, METH_VARARGS},
         {"rwaccess", rwaccess, METH_VARARGS},
+        {"replace_access_rights_event", replace_access_rights_event, METH_VARARGS},
         {"set_string_enum", set_string_enum, METH_VARARGS},
         {"is_string_enum", is_string_enum, METH_VARARGS},
         {"get_enum_strings", get_enum_strings, METH_VARARGS},
@@ -492,6 +505,7 @@ extern "C" {
         {"processor", T_OBJECT_EX, offsetof(capv, processor), 0, "processor"},
         {"connect_cb", T_OBJECT_EX, offsetof(capv, connect_cb), 0, "connect_cb"},
         {"monitor_cb", T_OBJECT_EX, offsetof(capv, monitor_cb), 0, "monitor_cb"},
+        {"rwaccess_cb", T_OBJECT_EX, offsetof(capv, rwaccess_cb), 0, "rwaccess_cb"},
         {"getevt_cb", T_OBJECT_EX, offsetof(capv, getevt_cb), 0, "getevt_cb"},
         {"putevt_cb", T_OBJECT_EX, offsetof(capv, putevt_cb), 0, "putevt_cb"},
         {"simulated", T_OBJECT_EX, offsetof(capv, simulated), 0, "simulated"},

--- a/pyca/pyca.hh
+++ b/pyca/pyca.hh
@@ -1,25 +1,26 @@
 // Structure to define a channel access PV for python
 struct capv {
   PyObject_HEAD
-  PyObject* name;      // PV name
-  PyObject* data;      // data dictionary
-  PyObject* processor; // user processor function
-  PyObject* connect_cb;// connection callback
-  PyObject* monitor_cb;// monitor callback
-  PyObject* getevt_cb; // event callback
-  PyObject* putevt_cb; // event callback
-  PyObject* simulated; // None if real PV, otherwise just simulated.
-  PyObject* use_numpy; // True to use numpy array instead of tuple
-  chid cid;            // channel access ID  
-  char* getbuffer;     // buffer for received data
-  unsigned getbufsiz;  // received data buffer size
-  char* putbuffer;     // buffer for send data
-  unsigned putbufsiz;  // send data buffer size
-  evid eid;            // monitor subscription
-  int string_enum;     // Should enum be numeric or string?
-  int count;           // How many elements are we monitoring?
-  int didget;          // for simulation.
-  int didmon;          // for simulation.
+  PyObject* name;       // PV name
+  PyObject* data;       // data dictionary
+  PyObject* processor;  // user processor function
+  PyObject* connect_cb; // connection callback
+  PyObject* monitor_cb; // monitor callback
+  PyObject* rwaccess_cb;// access rights callback 
+  PyObject* getevt_cb;  // event callback
+  PyObject* putevt_cb;  // event callback
+  PyObject* simulated;  // None if real PV, otherwise just simulated.
+  PyObject* use_numpy;  // True to use numpy array instead of tuple
+  chid cid;             // channel access ID  
+  char* getbuffer;      // buffer for received data
+  unsigned getbufsiz;   // received data buffer size
+  char* putbuffer;      // buffer for send data
+  unsigned putbufsiz;   // send data buffer size
+  evid eid;             // monitor subscription
+  int string_enum;      // Should enum be numeric or string?
+  int count;            // How many elements are we monitoring?
+  int didget;           // for simulation.
+  int didmon;           // for simulation.
 };
 
 // Possible exceptions

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,14 @@
 from setuptools import setup, Extension
-import os
+import os, sys
 import numpy as np
 
+if sys.platform == 'darwin':
+    libsrc = 'Darwin'
+elif sys.platform.startswith('linux'):
+    libsrc = 'Linux'
+else:
+    libsrc = None
+    
 epics_inc = os.getenv("EPICS_BASE") + "/include"
 epics_lib = os.getenv("EPICS_BASE") + "/lib/" + os.getenv("EPICS_HOST_ARCH")
 numpy_inc = np.get_include()
@@ -9,7 +16,7 @@ numpy_inc = np.get_include()
 pyca = Extension('pyca',
                  language='c++',
                  sources=['pyca/pyca.cc'],
-                 include_dirs=['pyca', epics_inc, epics_inc + '/os/Linux',
+                 include_dirs=['pyca', epics_inc, epics_inc + '/os/' + libsrc,
                                numpy_inc],
                  library_dirs=[epics_lib],
                  libraries=['Com', 'ca'])


### PR DESCRIPTION
This PR adds support for libca's 'ca_replace_access_rights_event()' function (see http://www.aps.anl.gov/epics/base/R3-14/8-docs/CAref.html#ca_replace), which lets you set callbacks for access state changes.  I've tried to follow the same pattern that gets used for connection and monitor callbacks.

pyca.capv gets a new attribute called 'rwaccess_cb', which stores the python method to run, and a new method called 'replace_access_rights_event()', which installs the callback.  The following code illustrates how it all works:

```
p = pyca.capv("MTEST:Float")
def access_change(readable, writeable):
    print("Read: {}".format(readable))
    print("Write: {}".format(writeable))
p.rwaccess_cb = access_change
p.create_channel()
p.replace_access_rights_event()
```

As you can see, the callback signature takes two booleans, one for the read access state, one for write access.

Bonus change: setup.py was modified so that pyca can be built on macOS in addition to Linux.