### PR TITLE
MAINT: Clean up conda recipe, add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+conda-bld-test
+setup-py-test
+build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 conda-bld-tst
 setup-py-tst
 build
+
+*.cache
+*.pyc
+__pycache__
+
+*.swp
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-conda-bld-test
-setup-py-test
+conda-bld-tst
+setup-py-tst
 build

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 
 *.swp
 *~
+
+logs

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,9 +1,9 @@
-{% set data = load_setup_py_data() %}
+{% set VERSION = '2.3.2' %}
 {% set EPICS = '3.14.12.6' %}
 
 package:
   name: pyca
-  version: {{ data.get('version') }}
+  version: {{ VERSION }}
 
 source:
   path: ..

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,12 +16,12 @@ requirements:
   build:
     - python {{PY_VER}}*,<3
     - setuptools
-    - epics-base {{EPICS}}
+    - epics-base {{EPICS}}*
     - numpy
 
   run:
     - python {{PY_VER}}*,<3
-    - epics-base {{EPICS}}
+    - epics-base {{EPICS}}*
     - numpy
 
 tests:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,19 +10,19 @@ source:
 
 build:
   number: 1
-  string: py{{py}}np{{np}}epics{{EPICS}}
+  string: py{{ py }}np{{ np }}epics{{ EPICS }}
 
 requirements:
   build:
-    - python {{PY_VER}}*,<3
+    - python {{ PY_VER }}*,<3
     - setuptools
-    - epics-base {{EPICS}}*
-    - numpy
+    - epics-base {{ EPICS }}*
+    - numpy {{ NPY_VER }}*
 
   run:
-    - python {{PY_VER}}*,<3
-    - epics-base {{EPICS}}*
-    - numpy
+    - python {{ PY_VER }}*,<3
+    - epics-base {{ EPICS }}*
+    - numpy {{ NPY_VER }}*
 
 tests:
   import:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,23 +1,32 @@
+{% set data = load_setup_py_data() %}
+{% set EPICS = '3.14.12.6' %}
+
 package:
   name: pyca
-  version: "2.3.1"
+  version: {{ data.get('version') }}
 
 source:
   path: ..
 
 build:
   number: 1
+  string: py{{py}}np{{np}}epics{{EPICS}}
 
 requirements:
   build:
     - python {{PY_VER}}*,<3
-    - epics-base
+    - setuptools
+    - epics-base {{EPICS}}
     - numpy
 
   run:
     - python {{PY_VER}}*,<3
-    - epics-base
+    - epics-base {{EPICS}}
     - numpy
+
+tests:
+  import:
+    pyca
 
 about:
   home: https://github.com/slaclab/pyca

--- a/pyca.txt
+++ b/pyca.txt
@@ -443,7 +443,7 @@ the request to be delivered to an IOC.
 
 pyca.capv methods you can override:
 
-1.  .connection_handler( self, is_connected )
+1.  .connect_cb( self, is_connected )
 
     Called when the connection status of the capv instance changes.
     'is_connected' is a boolean indicating the new state of the
@@ -454,7 +454,7 @@ pyca.capv methods you can override:
     When a previously connected PV disconnects, this method will be
     called with is_connected set to False.
 
-2.  .monitor_handler( self, exception=None )
+2.  .monitor_cb( self, exception=None )
 
     Called when the state of the PV changes.  The state change
     detected is specified by the 'mask' argument to
@@ -468,6 +468,6 @@ pyca.capv methods you can override:
     The items in the instance's 'data' dictionary will be updated with
     the PV's new status information.
 
-3.  .getevent_handler( self, exception=None )
+3.  .getevt_cb( self, exception=None )
 
     Called when an asynchronous retrieval ('get') completes.

--- a/run_tests.py
+++ b/run_tests.py
@@ -17,4 +17,29 @@ if __name__ == '__main__':
     txt = 'pytest arguments: {}'.format(args)
     print(txt)
 
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+    log_dir = os.path.join(os.path.dirname(__file__), 'logs')
+    log_filename = os.path.join(log_dir, 'debug.log')
+    if not os.path.exists(log_dir):
+        os.mkdir(log_dir)
+    if os.path.isfile(log_filename):
+        do_rollover = True
+    else:
+        do_rollover = False
+    handler = RotatingFileHandler(log_filename, backupCount=9)
+    if do_rollover:
+        handler.doRollover()
+    formatter = logging.Formatter(fmt=('%(asctime)s.%(msecs)03d '
+                                       '%(module)-10s '
+                                       '%(levelname)-8s '
+                                       '%(threadName)-10s '
+                                       '%(message)s'),
+                                  datefmt='%H:%M:%S')
+    handler.setFormatter(formatter)
+    root_logger.addHandler(handler)
+
+    logger = logging.getLogger(__name__)
+    logger.info(txt)
+
     sys.exit(pytest.main(args))

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import sys
+import os
+import logging
+from logging.handlers import RotatingFileHandler
+import pytest
+
+if __name__ == '__main__':
+    # Show output results from every test function
+    # Show the message output for skipped and expected failures
+    args = ['-v', '-vrxs']
+
+    # Add extra arguments
+    if len(sys.argv) > 1:
+        args.extend(sys.argv[1:])
+
+    txt = 'pytest arguments: {}'.format(args)
+    print(txt)
+
+    sys.exit(pytest.main(args))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ pyca = Extension('pyca',
                  library_dirs=[epics_lib],
                  libraries=['Com', 'ca'])
 
-setup(name='pyca', version='2.3.1',
+setup(name='pyca', version='2.3.2',
       description='python channel access library',
       ext_modules=[pyca], url='https://confluence.slac.stanford.edu/display/PCDS/Using+pyca',
       author='Amedeo Perazzo', author_email='amedeo@slac.stanford.edu')

--- a/test-conda.sh
+++ b/test-conda.sh
@@ -1,0 +1,2 @@
+mkdir -p conda-bld-tst
+conda build conda-recipe --output-folder conda-bld-tst --python 2.7 --numpy 1.13

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -1,6 +1,6 @@
-mkdir -p setup-py-test
+mkdir -p setup-py-tst
 python setup.py build
 LIB=`find build -name pyca.so`
-LINK='setup-py-test/pyca.so'
+LINK='setup-py-tst/pyca.so'
 rm $LINK
 ln -s $LIB $LINK

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -1,0 +1,6 @@
+mkdir -p setup-py-test
+python setup.py build
+LIB=`find build -name pyca.so`
+LINK='setup-py-test/pyca.so'
+rm $LINK
+ln -s $LIB $LINK

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 pvbase = "PYCA:TEST"
 pvdb = dict(
-    CHAR = dict(type="char"),
     LONG = dict(type="int"),
     DOUBLE = dict(type="float"),
     STRING = dict(type="string"),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ pvdb = dict(
     DOUBLE = dict(type="float"),
     STRING = dict(type="string"),
     ENUM = dict(type="enum", enums=["zero", "one", "two", "three"]),
-    WAVE = dict(type="char", count=10)
+    WAVE = dict(type="int", count=10)
 )
 test_pvs = [pvbase + ":" + key for key in pvdb.keys()]
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,58 @@
+import threading
+import pyca
+import pytest
+
+test_pvs = dict(
+    dbr_string_t='XPP:USR:MMS:01.DESC',
+    dbr_enum_t='HX2:SB1:PIM',
+    #dbr_char_t=None,
+    #dbr_short_t=None,
+    #dbr_ulong_t=None,
+    dbr_long_t='XPP:USR:MMS:01.RC',
+    #dbr_float_t=None,
+    dbr_double_t='XPP:USR:MMS:01')
+
+class ConnectCallback(object):
+    def __init__(self):
+        self.connected = False
+        self.cev = threading.Event()
+        self.dcev = threading.Event()
+        self.lock = threading.RLock()
+
+    def wait(self, timeout=None):
+        self.cev.wait(timeout=timeout)
+
+    def wait_dc(self, timeout=None):
+        self.dcev.wait(timeout=timeout)
+
+    def __call__(self, is_connected):
+        with self.lock:
+            self.connected = is_connected
+            if self.connected:
+                self.cev.set()
+                self.dcev.clear()
+            else:
+                self.dcev.set()
+                self.cev.clear()
+
+
+class GetCallback(object):
+    def __init__(self):
+        self.gev = threading.Event()
+
+    def wait(self, timeout=None):
+        self.gev.wait(timeout=timeout)
+
+    def reset(self):
+        self.gev.clear()
+
+    def __call__(self, exception=None):
+        if exception is None:
+            self.gev.set()
+
+@pytest.fixture(scope='function'):
+def waveform_pv():
+    pv = pyca.capv(INSERTNAMEHERE)
+    pv.connection_handler = ConnectCallback()
+    pv.getevent_handler = GetCallback()
+    return pv

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,6 +12,7 @@ test_pvs = dict(
     #dbr_float_t=None,
     dbr_double_t='XPP:USR:MMS:01')
 
+
 class ConnectCallback(object):
     def __init__(self):
         self.connected = False
@@ -49,6 +50,7 @@ class GetCallback(object):
     def __call__(self, exception=None):
         if exception is None:
             self.gev.set()
+
 
 @pytest.fixture(scope='function')
 def waveform_pv():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -50,7 +50,7 @@ class GetCallback(object):
         if exception is None:
             self.gev.set()
 
-@pytest.fixture(scope='function'):
+@pytest.fixture(scope='function')
 def waveform_pv():
     pv = pyca.capv(INSERTNAMEHERE)
     pv.connection_handler = ConnectCallback()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -53,6 +53,6 @@ class GetCallback(object):
 @pytest.fixture(scope='function')
 def waveform_pv():
     pv = pyca.capv(INSERTNAMEHERE)
-    pv.connection_handler = ConnectCallback()
-    pv.getevent_handler = GetCallback()
+    pv.connect_cb = ConnectCallback()
+    pv.getevt_cb = GetCallback()
     return pv

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,7 +52,7 @@ class GetCallback(object):
 
 @pytest.fixture(scope='function')
 def waveform_pv():
-    pv = pyca.capv(INSERTNAMEHERE)
+    pv = pyca.capv('XPP:USR:MMS:01.LOGA')
     pv.connect_cb = ConnectCallback()
     pv.getevt_cb = GetCallback()
     return pv

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ pvdb = dict(
     DOUBLE = dict(type="float"),
     STRING = dict(type="string"),
     ENUM = dict(type="enum", enums=["zero", "one", "two", "three"]),
-    WAVE = dict(type="char", count=100)
+    WAVE = dict(type="char", count=10)
 )
 test_pvs = [pvbase + ":" + key for key in pvdb.keys()]
 

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -1,0 +1,75 @@
+import time
+import pytest
+import numpy as np
+import pyca
+from conftest import test_pvs, ConnectCallback, GetCallback
+
+@pytest.mark.parametrize('pvname', test_pvs.values())
+def test_create_and_clear_channel(pvname):
+    pv = pyca.capv(pvname)
+    pv.connection_handler = ConnectCallback()
+    pv.create_channel()
+    pv.connection_handler.wait(timeout=1)
+    assert pv.connection_handler.connected
+    pv.clear_channel()
+    pv.connection_handler.wait_dc(timeout=1)
+    assert not pv.connection_handler.connected
+
+
+@pytest.mark.parametrize('pvname', test_pvs.values())
+def test_get_data(pvname):
+    pv = pyca.capv(pvname)
+    pv.connection_handler = ConnectCallback()
+    pv.getevent_handler = GetCallback()
+    pv.create_channel()
+    pv.connection_handler.wait(timeout=1)
+    # get ctrl vars
+    pv.get_data(True, 1.0)
+    # get time vars
+    pv.get_data(False, 1.0)
+    # check that the data has all the keys
+    all_keys = ('status', 'warn_llim', 'severity', 'alarm_hlim', 'warn_hlim',
+                'alarm_llim', 'precision', 'value', 'display_llim', 'secs',
+                'nsec', 'ctrl_llim', 'units', 'ctrl_hlim', 'display_hlim')
+    for key in all_keys:
+        assert key in pv.data
+    # check that value is not None
+    assert pv.data['value'] is not None
+
+
+@pytest.mark.parametrize('pvname', test_pvs.values())
+def test_subscribe(pvname):
+    pv = pyca.capv(pvname)
+    pv.connection_handler = ConnectCallback()
+    pv.create_channel()
+    pv.connection_handler.wait(timeout=1)
+    # Just make sure nothing bad happens
+    pv.subscribe_channel()
+    time.sleep(1)
+
+
+@pytest.mark.parametrize('pvname', test_pvs.values())
+def test_misc(pvname):
+    pv = pyca.capv(pvname)
+    pv.connection_handler = ConnectCallback()
+    pv.create_channel()
+    pv.connection_handler.wait(timeout=1)
+    assert isinstance(pv.host(), str)
+    assert isinstance(pv.state(), int)
+    assert pv.count() == 1
+    assert isinstance(pv.type(), str)
+    assert isinstance(pv.rwaccess(), int)
+
+
+def test_waveform(waveform_pv):
+    waveform_pv.create_channel()
+    waveform_pv.connection_handler.wait(timeout=1)
+    # Do as a tuple
+    waveform_pv.numpy_arrays = False
+    val = waveform_pv.data['value']
+    assert isinstance(val, tuple)
+    assert len(val) == waveform_pv.count()
+    # Do as a np.ndarray
+    waveform_pv.numpy_arrays = True
+    assert isinstance(val, np.ndarray)
+    assert len(val) == waveform_pv.count()

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -63,11 +63,11 @@ def test_waveform(waveform_pv):
     waveform_pv.create_channel()
     waveform_pv.connect_cb.wait(timeout=1)
     # Do as a tuple
-    waveform_pv.numpy_arrays = False
+    waveform_pv.use_numpy = False
     val = waveform_pv.data['value']
     assert isinstance(val, tuple)
     assert len(val) == waveform_pv.count()
     # Do as a np.ndarray
-    waveform_pv.numpy_arrays = True
+    waveform_pv.use_numpy = True
     assert isinstance(val, np.ndarray)
     assert len(val) == waveform_pv.count()

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -65,7 +65,7 @@ def test_waveform(waveform_pv):
     waveform_pv.connect_cb.wait(timeout=1)
     # Do as a tuple
     waveform_pv.use_numpy = False
-    waveform_pv.get_data()
+    waveform_pv.get_data(False, 1.0)
     waveform_pv.getevt_cb.wait(timeout=1)
     val = waveform_pv.data['value']
     assert isinstance(val, tuple)
@@ -73,7 +73,7 @@ def test_waveform(waveform_pv):
     waveform_pv.getevt_cb.reset()
     # Do as a np.ndarray
     waveform_pv.use_numpy = True
-    waveform_pv.get_data()
+    waveform_pv.get_data(False, 1.0)
     waveform_pv.getevt_cb.wait(timeout=1)
     assert isinstance(val, np.ndarray)
     assert len(val) == waveform_pv.count()

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -23,10 +23,11 @@ def test_get_data(pvname):
     pv.getevt_cb = GetCallback()
     pv.create_channel()
     pv.connect_cb.wait(timeout=1)
-    # get ctrl vars
-    pv.get_data(True, 1.0)
     # get time vars
     pv.get_data(False, 1.0)
+    if not isinstance(pv.data['value'], str):
+        # get ctrl vars
+        pv.get_data(True, 1.0)
     # check that the data has all the keys
     all_keys = ('status', 'value', 'secs', 'nsec')
     for key in all_keys:

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -75,5 +75,6 @@ def test_waveform(waveform_pv):
     waveform_pv.use_numpy = True
     waveform_pv.get_data(False, 1.0)
     waveform_pv.getevt_cb.wait(timeout=1)
+    val = waveform_pv.data['value']
     assert isinstance(val, np.ndarray)
     assert len(val) == waveform_pv.count()

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -114,7 +114,7 @@ def test_misc(pvname):
     pv = setup_pv(pvname)
     assert isinstance(pv.host(), str)
     assert isinstance(pv.state(), int)
-    assert pv.count() == 1
+    assert isinstance(pv.count(), int)
     assert isinstance(pv.type(), str)
     assert isinstance(pv.rwaccess(), int)
 
@@ -151,9 +151,9 @@ def test_threads():
         pv.get_data(False, -1.0)
         pyca.flush_io()
         assert pv.getevt_cb.wait(timeout=1)
+        assert isinstance(pv.data['value'], tuple)
 
     pvname = pvbase + ":WAVE"
     thread = threading.Thread(target=some_thread_thing, args=(pvname,))
     thread.start()
     thread.join()
-    assert isinstance(pv.data['value'], tuple)

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -4,6 +4,7 @@ import numpy as np
 import pyca
 from conftest import test_pvs, ConnectCallback, GetCallback
 
+
 @pytest.mark.parametrize('pvname', test_pvs.values())
 def test_create_and_clear_channel(pvname):
     pv = pyca.capv(pvname)

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -1,9 +1,12 @@
 import time
 import threading
+import logging
 import pytest
 import numpy as np
 import pyca
 from conftest import test_pvs, ConnectCallback, GetCallback, setup_pv, pvbase
+
+logger = logging.getLogger(__name__)
 
 
 def test_server_start(server):
@@ -13,6 +16,7 @@ def test_server_start(server):
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
 def test_create_and_clear_channel(pvname):
+    logger.debug('test_create_and_clear_channel %s', pvname)
     pv = setup_pv(pvname)
     assert pv.connect_cb.connected
     # No callbacks on dc
@@ -25,12 +29,16 @@ def test_create_and_clear_channel(pvname):
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
 def test_get_data(pvname):
+    logger.debug('test_get_data %s', pvname)
     pv = setup_pv(pvname)
     # get time vars
-    pv.get_data(False, 1.0)
+    pv.get_data(False, 0.0)
+    assert pv.getevt_cb.wait(timeout=1)
+    assert pv.getevt_cb.reset()
     if not isinstance(pv.data['value'], str):
         # get ctrl vars
-        pv.get_data(True, 1.0)
+        pv.get_data(True, 0.0)
+        assert pv.getevt_cb.wait(timeout=1)
     # check that the data has all the keys
     all_keys = ('status', 'value', 'secs', 'nsec')
     for key in all_keys:
@@ -42,9 +50,10 @@ def test_get_data(pvname):
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
 def test_put_get(pvname):
+    logger.debug('test_put_get %s', pvname)
     pv = setup_pv(pvname)
     pv.get_data(False, 0.0)
-    pv.getevt_cb.wait()
+    assert pv.getevt_cb.wait(timeout=1)
     old_value = pv.data['value']
     pv_type = type(old_value)
     if pv_type in (int, long, float):
@@ -55,10 +64,10 @@ def test_put_get(pvname):
         new_value = tuple([1] * len(old_value))
     pv.getevt_cb.reset()
     pv.put_data(new_value, 0.0)
-    pv.getevt_cb.wait()
+    assert pv.getevt_cb.wait(timeout=1)
     pv.getevt_cb.reset()
     pv.get_data(False, 0.0)
-    pv.getevt_cb.wait()
+    assert pv.getevt_cb.wait(timeout=1)
     recv_value = pv.data['value']
     assert recv_value == new_value
 
@@ -66,6 +75,7 @@ def test_put_get(pvname):
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
 def test_subscribe(pvname):
+    logger.debug('test_subscribe %s', pvname)
     pv = setup_pv(pvname)
     ev = threading.Event()
     def mon_cb(exception=None):
@@ -75,7 +85,7 @@ def test_subscribe(pvname):
     pv.subscribe_channel(pyca.DBE_VALUE | pyca.DBE_LOG | pyca.DBE_ALARM, False)
     # Repeat the put/get test without the get
     pv.get_data(False, 0.0)
-    pv.getevt_cb.wait()
+    assert pv.getevt_cb.wait(timeout=1)
     old_value = pv.data['value']
     pv_type = type(old_value)
     if pv_type in (int, long, float):
@@ -86,7 +96,7 @@ def test_subscribe(pvname):
         new_value = tuple([1] * len(old_value))
     pv.getevt_cb.reset()
     pv.put_data(new_value, 0.0)
-    pv.getevt_cb.wait()
+    assert pv.getevt_cb.wait(timeout=1)
     recv_value = pv.data['value']
     assert recv_value == new_value
     # Verify that monitor_cb was called
@@ -96,6 +106,7 @@ def test_subscribe(pvname):
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
 def test_misc(pvname):
+    logger.debug('test_misc %s', pvname)
     pv = setup_pv(pvname)
     assert isinstance(pv.host(), str)
     assert isinstance(pv.state(), int)
@@ -106,11 +117,12 @@ def test_misc(pvname):
 
 @pytest.mark.timeout(10)
 def test_waveform():
+    logger.debug('test_waveform')
     pv = setup_pv(pvbase + ":WAVE")
     # Do as a tuple
     pv.use_numpy = False
     pv.get_data(False, 0.0)
-    pv.getevt_cb.wait(timeout=1)
+    assert pv.getevt_cb.wait(timeout=1)
     val = pv.data['value']
     assert isinstance(val, tuple)
     assert len(val) == pv.count()
@@ -118,7 +130,7 @@ def test_waveform():
     # Do as a np.ndarray
     pv.use_numpy = True
     pv.get_data(False, 0.0)
-    pv.getevt_cb.wait(timeout=1)
+    assert pv.getevt_cb.wait(timeout=1)
     val = pv.data['value']
     assert isinstance(val, np.ndarray)
     assert len(val) == pv.count()
@@ -126,11 +138,12 @@ def test_waveform():
 
 @pytest.mark.timeout(10)
 def test_threads():
+    logger.debug('test_threads')
     def some_thread_thing(pvname):
         pyca.attach_context()
         pv = setup_pv(pvname)
         pv.get_data(False, 0.0)
-        pv.getevt_cb.wait(timeout=1)
+        assert pv.getevt_cb.wait(timeout=1)
 
     pvname = pvbase + ":WAVE"
     thread = threading.Thread(target=some_thread_thing, args=(pvname,))

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -103,6 +103,7 @@ def test_subscribe(pvname):
     elif pv_type == tuple:
         new_value = tuple([1] * len(old_value))
     logger.debug('caput %s %s', pvname, new_value)
+    ev.clear()
     pv.put_data(new_value, 1.0)
     assert ev.wait(timeout=1)
     recv_value = pv.data['value']

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -7,22 +7,22 @@ from conftest import test_pvs, ConnectCallback, GetCallback
 @pytest.mark.parametrize('pvname', test_pvs.values())
 def test_create_and_clear_channel(pvname):
     pv = pyca.capv(pvname)
-    pv.connection_handler = ConnectCallback()
+    pv.connect_cb = ConnectCallback()
     pv.create_channel()
-    pv.connection_handler.wait(timeout=1)
-    assert pv.connection_handler.connected
+    pv.connect_cb.wait(timeout=1)
+    assert pv.connect_cb.connected
     pv.clear_channel()
-    pv.connection_handler.wait_dc(timeout=1)
-    assert not pv.connection_handler.connected
+    pv.connect_cb.wait_dc(timeout=1)
+    assert not pv.connect_cb.connected
 
 
 @pytest.mark.parametrize('pvname', test_pvs.values())
 def test_get_data(pvname):
     pv = pyca.capv(pvname)
-    pv.connection_handler = ConnectCallback()
-    pv.getevent_handler = GetCallback()
+    pv.connect_cb = ConnectCallback()
+    pv.getevt_cb = GetCallback()
     pv.create_channel()
-    pv.connection_handler.wait(timeout=1)
+    pv.connect_cb.wait(timeout=1)
     # get ctrl vars
     pv.get_data(True, 1.0)
     # get time vars
@@ -40,9 +40,9 @@ def test_get_data(pvname):
 @pytest.mark.parametrize('pvname', test_pvs.values())
 def test_subscribe(pvname):
     pv = pyca.capv(pvname)
-    pv.connection_handler = ConnectCallback()
+    pv.connect_cb = ConnectCallback()
     pv.create_channel()
-    pv.connection_handler.wait(timeout=1)
+    pv.connect_cb.wait(timeout=1)
     # Just make sure nothing bad happens
     pv.subscribe_channel()
     time.sleep(1)
@@ -51,9 +51,9 @@ def test_subscribe(pvname):
 @pytest.mark.parametrize('pvname', test_pvs.values())
 def test_misc(pvname):
     pv = pyca.capv(pvname)
-    pv.connection_handler = ConnectCallback()
+    pv.connect_cb = ConnectCallback()
     pv.create_channel()
-    pv.connection_handler.wait(timeout=1)
+    pv.connect_cb.wait(timeout=1)
     assert isinstance(pv.host(), str)
     assert isinstance(pv.state(), int)
     assert pv.count() == 1
@@ -63,7 +63,7 @@ def test_misc(pvname):
 
 def test_waveform(waveform_pv):
     waveform_pv.create_channel()
-    waveform_pv.connection_handler.wait(timeout=1)
+    waveform_pv.connect_cb.wait(timeout=1)
     # Do as a tuple
     waveform_pv.numpy_arrays = False
     val = waveform_pv.data['value']

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -64,10 +64,15 @@ def test_waveform(waveform_pv):
     waveform_pv.connect_cb.wait(timeout=1)
     # Do as a tuple
     waveform_pv.use_numpy = False
+    waveform_pv.get_data()
+    waveform_pv.getevt_cb.wait(timeout=1)
     val = waveform_pv.data['value']
     assert isinstance(val, tuple)
     assert len(val) == waveform_pv.count()
+    waveform_pv.getevt_cb.reset()
     # Do as a np.ndarray
     waveform_pv.use_numpy = True
+    waveform_pv.get_data()
+    waveform_pv.getevt_cb.wait(timeout=1)
     assert isinstance(val, np.ndarray)
     assert len(val) == waveform_pv.count()

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -83,6 +83,8 @@ def test_subscribe(pvname):
     pv = setup_pv(pvname)
     ev = threading.Event()
     def mon_cb(exception=None):
+        logger.debug('monitor_cb in %s, exception=%s',
+                     pvname, exception)
         if exception is not None:
             ev.set()
     pv.monitor_cb = mon_cb

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -11,9 +11,11 @@ def test_create_and_clear_channel(pvname):
     pv.create_channel()
     pv.connect_cb.wait(timeout=1)
     assert pv.connect_cb.connected
+    # No callbacks on dc
     pv.clear_channel()
-    pv.connect_cb.wait_dc(timeout=1)
-    assert not pv.connect_cb.connected
+    time.sleep(1)
+    with pytest.raises(pyca.pyexc):
+        pv.get_data()
 
 
 @pytest.mark.parametrize('pvname', test_pvs.values())

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -99,7 +99,7 @@ def test_subscribe(pvname):
     if pv_type in (int, long, float):
         new_value = old_value + 1
     elif pv_type == str:
-        new_value = "putget"
+        new_value = "putmon"
     elif pv_type == tuple:
         new_value = tuple([1] * len(old_value))
     logger.debug('caput %s %s', pvname, new_value)

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -85,7 +85,7 @@ def test_subscribe(pvname):
     def mon_cb(exception=None):
         logger.debug('monitor_cb in %s, exception=%s',
                      pvname, exception)
-        if exception is not None:
+        if exception is None:
             ev.set()
     pv.monitor_cb = mon_cb
     pv.subscribe_channel(pyca.DBE_VALUE | pyca.DBE_LOG | pyca.DBE_ALARM, False)

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -3,15 +3,17 @@ import threading
 import pytest
 import numpy as np
 import pyca
-from conftest import test_pvs, ConnectCallback, GetCallback
+from conftest import test_pvs, ConnectCallback, GetCallback, setup_pv, pvbase
 
 
-@pytest.mark.parametrize('pvname', test_pvs.values())
+def test_server_start(server):
+    pass
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize('pvname', test_pvs)
 def test_create_and_clear_channel(pvname):
-    pv = pyca.capv(pvname)
-    pv.connect_cb = ConnectCallback()
-    pv.create_channel()
-    pv.connect_cb.wait(timeout=1)
+    pv = setup_pv(pvname)
     assert pv.connect_cb.connected
     # No callbacks on dc
     pv.clear_channel()
@@ -20,13 +22,10 @@ def test_create_and_clear_channel(pvname):
         pv.get_data()
 
 
-@pytest.mark.parametrize('pvname', test_pvs.values())
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize('pvname', test_pvs)
 def test_get_data(pvname):
-    pv = pyca.capv(pvname)
-    pv.connect_cb = ConnectCallback()
-    pv.getevt_cb = GetCallback()
-    pv.create_channel()
-    pv.connect_cb.wait(timeout=1)
+    pv = setup_pv(pvname)
     # get time vars
     pv.get_data(False, 1.0)
     if not isinstance(pv.data['value'], str):
@@ -40,23 +39,64 @@ def test_get_data(pvname):
     assert pv.data['value'] is not None
 
 
-@pytest.mark.parametrize('pvname', test_pvs.values())
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize('pvname', test_pvs)
+def test_put_get(pvname):
+    pv = setup_pv(pvname)
+    pv.get_data(False, 0.0)
+    pv.getevt_cb.wait()
+    old_value = pv.data['value']
+    pv_type = type(old_value)
+    if pv_type in (int, long, float):
+        new_value = old_value + 1
+    elif pv_type == str:
+        new_value = "putget"
+    elif pv_type == tuple:
+        new_value = tuple([1] * len(old_value))
+    pv.getevt_cb.reset()
+    pv.put_data(new_value, 0.0)
+    pv.getevt_cb.wait()
+    pv.getevt_cb.reset()
+    pv.get_data(False, 0.0)
+    pv.getevt_cb.wait()
+    recv_value = pv.data['value']
+    assert recv_value == new_value
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize('pvname', test_pvs)
 def test_subscribe(pvname):
-    pv = pyca.capv(pvname)
-    pv.connect_cb = ConnectCallback()
-    pv.create_channel()
-    pv.connect_cb.wait(timeout=1)
-    # Just make sure nothing bad happens
+    pv = setup_pv(pvname)
+    ev = threading.Event()
+    def mon_cb(exception=None):
+        if exception is not None:
+            ev.set()
+    pv.monitor_cb = mon_cb
     pv.subscribe_channel(pyca.DBE_VALUE | pyca.DBE_LOG | pyca.DBE_ALARM, False)
-    time.sleep(1)
+    # Repeat the put/get test without the get
+    pv.get_data(False, 0.0)
+    pv.getevt_cb.wait()
+    old_value = pv.data['value']
+    pv_type = type(old_value)
+    if pv_type in (int, long, float):
+        new_value = old_value + 1
+    elif pv_type == str:
+        new_value = "putget"
+    elif pv_type == tuple:
+        new_value = tuple([1] * len(old_value))
+    pv.getevt_cb.reset()
+    pv.put_data(new_value, 0.0)
+    pv.getevt_cb.wait()
+    recv_value = pv.data['value']
+    assert recv_value == new_value
+    # Verify that monitor_cb was called
+    assert ev.is_set()
 
 
-@pytest.mark.parametrize('pvname', test_pvs.values())
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize('pvname', test_pvs)
 def test_misc(pvname):
-    pv = pyca.capv(pvname)
-    pv.connect_cb = ConnectCallback()
-    pv.create_channel()
-    pv.connect_cb.wait(timeout=1)
+    pv = setup_pv(pvname)
     assert isinstance(pv.host(), str)
     assert isinstance(pv.state(), int)
     assert pv.count() == 1
@@ -64,35 +104,36 @@ def test_misc(pvname):
     assert isinstance(pv.rwaccess(), int)
 
 
-def test_waveform(waveform_pv):
-    waveform_pv.create_channel()
-    waveform_pv.connect_cb.wait(timeout=1)
+@pytest.mark.timeout(10)
+def test_waveform():
+    pv = setup_pv(pvbase + ":WAVE")
     # Do as a tuple
-    waveform_pv.use_numpy = False
-    waveform_pv.get_data(False, 0.0)
-    waveform_pv.getevt_cb.wait(timeout=1)
-    val = waveform_pv.data['value']
+    pv.use_numpy = False
+    pv.get_data(False, 0.0)
+    pv.getevt_cb.wait(timeout=1)
+    val = pv.data['value']
     assert isinstance(val, tuple)
-    assert len(val) == waveform_pv.count()
-    waveform_pv.getevt_cb.reset()
+    assert len(val) == pv.count()
+    pv.getevt_cb.reset()
     # Do as a np.ndarray
-    waveform_pv.use_numpy = True
-    waveform_pv.get_data(False, 0.0)
-    waveform_pv.getevt_cb.wait(timeout=1)
-    val = waveform_pv.data['value']
+    pv.use_numpy = True
+    pv.get_data(False, 0.0)
+    pv.getevt_cb.wait(timeout=1)
+    val = pv.data['value']
     assert isinstance(val, np.ndarray)
-    assert len(val) == waveform_pv.count()
+    assert len(val) == pv.count()
 
 
-def test_threads(waveform_pv):
-    def some_thread_thing(pv):
+@pytest.mark.timeout(10)
+def test_threads():
+    def some_thread_thing(pvname):
         pyca.attach_context()
-        pv.create_channel()
-        pv.connect_cb.wait(timeout=1)
+        pv = setup_pv(pvname)
         pv.get_data(False, 0.0)
         pv.getevt_cb.wait(timeout=1)
 
-    thread = threading.Thread(target=some_thread_thing, args=(waveform_pv,))
+    pvname = pvbase + ":WAVE"
+    thread = threading.Thread(target=some_thread_thing, args=(pvname,))
     thread.start()
     thread.join()
-    assert isinstance(waveform_pv.data['value'], tuple)
+    assert isinstance(pv.data['value'], tuple)

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -28,9 +28,7 @@ def test_get_data(pvname):
     # get time vars
     pv.get_data(False, 1.0)
     # check that the data has all the keys
-    all_keys = ('status', 'warn_llim', 'severity', 'alarm_hlim', 'warn_hlim',
-                'alarm_llim', 'precision', 'value', 'display_llim', 'secs',
-                'nsec', 'ctrl_llim', 'units', 'ctrl_hlim', 'display_hlim')
+    all_keys = ('status', 'value', 'secs', 'nsec')
     for key in all_keys:
         assert key in pv.data
     # check that value is not None

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -44,7 +44,7 @@ def test_subscribe(pvname):
     pv.create_channel()
     pv.connect_cb.wait(timeout=1)
     # Just make sure nothing bad happens
-    pv.subscribe_channel()
+    pv.subscribe_channel(pyca.DBE_VALUE | pyca.DBE_LOG | pyca.DBE_ALARM, False)
     time.sleep(1)
 
 


### PR DESCRIPTION
My next goal is to make pyca available in python 3, but before doing this I wanted to make sure I had a baseline for conda build functionality and pyca working state. I didn't exhaustively test all features and edge cases, but the goal was to make sure that the baseline features work the same before and after the transition to python 3, given that simple things like the definitions of int and long and the unicode vs bytestring thing have changed, which could affect how we interpret EPICS PVs.

Specific changes:
- `test` directory added with basic tests. You can run the tests using `python run_tests.py`, they require `pytest`, `pcaspy`, and an actually built and installed version of `pyca.so`.
- `meta.yaml` file requires pyca to be run with the same versions of numpy and epics used to build it
- `meta.yaml` file includes numpy and epics versions in build string
- convenience scripts for testing build with and without conda added
- version number bumped up
- some typos fixed in `pyca.txt` doc
- `.gitignore` added

This pull request is a formality, I will merge it myself tomorrow afternoon. No core features of pyca have changed.