### PR TITLE
Python 3 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 *~
 
 logs
+pyca.so

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
 # pyca
 
 PyCA (Python Channel Access) is a module that offers lightweight bindings for Python applications to access EPICS PVs. It acts as a channel access client, much like pyepics. The intention of the module is to provide better performance for embedded applications, rather than to provide an interactive interface. The most significant gains will be found when monitoring large waveforms that need to be processed before exposing them the Python layer.
-
-### todo list
-- cleaner documentation
-- combine with psp layer to be installed together
-- travis ci

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # pyca
 
-Pyca, which stands for Python Channel Access, is a module that offers lightweight bindings for Python applications to access EPICS PVs. It acts as a channel access client, much like pyepics. The intention of the module is to provide better performance for embedded applications, rather than to provide an interactive interface. The most significant gains will be found when monitoring large waveforms that need to be processed before exposing them the Python layer.
-
-This module was imported from an old svn repository and was previously used only for internal projects. I plan to clean it up a bit and have a working conda recipe before tagging a public release. The module is typically used with another interface layer called psp, which I will also bring to git and github at some point.
+PyCA (Python Channel Access) is a module that offers lightweight bindings for Python applications to access EPICS PVs. It acts as a channel access client, much like pyepics. The intention of the module is to provide better performance for embedded applications, rather than to provide an interactive interface. The most significant gains will be found when monitoring large waveforms that need to be processed before exposing them the Python layer.
 
 ### todo list
 - cleaner documentation
-- Python 3 compatibility
+- combine with psp layer to be installed together
+- travis ci

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set VERSION = '2.3.2' %}
+{% set VERSION = '3.0.0' %}
 {% set EPICS = '3.14.12.6' %}
 
 package:
@@ -14,13 +14,13 @@ build:
 
 requirements:
   build:
-    - python {{ PY_VER }}*,<3
+    - python {{ PY_VER }}*
     - setuptools
     - epics-base {{ EPICS }}*
     - numpy {{ NPY_VER }}*
 
   run:
-    - python {{ PY_VER }}*,<3
+    - python {{ PY_VER }}*
     - epics-base {{ EPICS }}*
     - numpy {{ NPY_VER }}*
 

--- a/pyca/getfunctions.hh
+++ b/pyca/getfunctions.hh
@@ -1,3 +1,4 @@
+#include "p3compat.h"
 // Channel access GET template functions
 static inline PyObject* _pyca_get(const dbr_string_t value)
 {

--- a/pyca/getfunctions.hh
+++ b/pyca/getfunctions.hh
@@ -45,7 +45,7 @@ static inline PyObject* _pyca_get(const dbr_double_t value)
 // if present, that method is invoked. This mechanism may avoid
 // unncessary data copies and it may be useful for large arrays.
 
-typedef void (*processptr)(const void* cadata, long count, size_t size, void* descr);
+typedef void (*processptr)(const void* cadata, long count, size_t size);
 
 // EPICS      Description                Numpy
 // DBR_STRING 40 character string`       NPY_STRING
@@ -117,9 +117,9 @@ PyObject* _pyca_get_value(capv* pv, const T* dbrv, long count)
         return pytup;
       }
     } else {
-      processptr process = (processptr)PyCObject_AsVoidPtr(pv->processor);
-      void* descr = PyCObject_GetDesc(pv->processor);
-      process(&(dbrv->value), count, sizeof(dbrv->value), descr);
+      const char* name = PyCapsule_GetName(pv->processor);
+      processptr process = (processptr)PyCapsule_GetPointer(pv->processor, name);
+      process(&(dbrv->value), count, sizeof(dbrv->value));
       return NULL;
     }
   }

--- a/pyca/getfunctions.hh
+++ b/pyca/getfunctions.hh
@@ -118,9 +118,14 @@ PyObject* _pyca_get_value(capv* pv, const T* dbrv, long count)
         return pytup;
       }
     } else {
+#ifdef IS_PY3K
       const char* name = PyCapsule_GetName(pv->processor);
       processptr process = (processptr)PyCapsule_GetPointer(pv->processor, name);
       void* descr = PyCapsule_GetContext(pv->processor);
+#else
+      processptr process = (processptr)PyCObject_AsVoidPtr(pv->processor);
+      void* descr = PyCObject_GetDesc(pv->processor);
+#endif
       process(&(dbrv->value), count, sizeof(dbrv->value), descr);
       return NULL;
     }

--- a/pyca/getfunctions.hh
+++ b/pyca/getfunctions.hh
@@ -46,7 +46,7 @@ static inline PyObject* _pyca_get(const dbr_double_t value)
 // if present, that method is invoked. This mechanism may avoid
 // unncessary data copies and it may be useful for large arrays.
 
-typedef void (*processptr)(const void* cadata, long count, size_t size);
+typedef void (*processptr)(const void* cadata, long count, size_t size, void* descr);
 
 // EPICS      Description                Numpy
 // DBR_STRING 40 character string`       NPY_STRING
@@ -120,7 +120,8 @@ PyObject* _pyca_get_value(capv* pv, const T* dbrv, long count)
     } else {
       const char* name = PyCapsule_GetName(pv->processor);
       processptr process = (processptr)PyCapsule_GetPointer(pv->processor, name);
-      process(&(dbrv->value), count, sizeof(dbrv->value));
+      void* descr = PyCapsule_GetContext(pv->processor);
+      process(&(dbrv->value), count, sizeof(dbrv->value), descr);
       return NULL;
     }
   }

--- a/pyca/handlers.hh
+++ b/pyca/handlers.hh
@@ -1,3 +1,4 @@
+#include "p3compat.h"
 // Utility function to pack eventual arguments for callback
 PyObject* pyca_new_cbtuple(PyObject* arg)
 {

--- a/pyca/p3compat.h
+++ b/pyca/p3compat.h
@@ -1,0 +1,53 @@
+#if PY_MAJOR_VERSION >= 3
+#define IS_PY3K
+#define DECLARE_INIT(name)  PyMODINIT_FUNC PyInit_##name(void)
+#define INITERROR           return NULL
+#define PyInt_Check         PyLong_Check
+#define PyInt_CheckExact    PyLong_CheckExact
+#define PyInt_AsLong        PyLong_AsLong
+#define PyInt_FromLong      PyLong_FromLong
+#define PyString_FromString PyUnicode_FromString
+#define PyString_Check      PyUnicode_Check
+// This should suffice, as long as we don't call this twice and try to hold onto both!
+static const char *PyString_AsString(PyObject *o)
+{
+    static char *result = NULL;
+    if (result) {
+        free(result);
+        result = NULL;
+    }
+    if (PyUnicode_Check(o)) {
+        PyObject *temp_bytes = PyUnicode_AsEncodedString(o, "ASCII", "strict");
+        if (temp_bytes != NULL) {
+            result = PyBytes_AS_STRING(temp_bytes);
+            result = strdup(result);
+            Py_DECREF(temp_bytes);
+            return result;
+        } else {
+            return NULL;
+        }
+    } else
+        return NULL;
+}
+
+static int PyString_Size(PyObject *o)
+{
+    int result;
+    if (PyUnicode_Check(o)) {
+        PyObject *temp_bytes = PyUnicode_AsEncodedString(o, "ASCII", "strict");
+        if (temp_bytes != NULL) {
+            result = PyBytes_GET_SIZE(temp_bytes);
+            Py_DECREF(temp_bytes);
+            return result;
+        } else {
+            return 0;
+        }
+    } else
+        return 0;
+}
+#else
+#define DECLARE_INIT(name)  PyMODINIT_FUNC init##name(void)
+#define INITERROR           return
+#define Py_TYPE(o)          ((o)->ob_type)
+#define PyVarObject_HEAD_INIT(type, size)   PyObject_HEAD_INIT(type) size,
+#endif

--- a/pyca/p3compat.h
+++ b/pyca/p3compat.h
@@ -1,3 +1,6 @@
+#ifndef PYCA_P3COMPAT
+#define PYCA_P3COMPAT
+#endif
 #if PY_MAJOR_VERSION >= 3
 #define IS_PY3K
 #define DECLARE_INIT(name)  PyMODINIT_FUNC PyInit_##name(void)

--- a/pyca/p3compat.h
+++ b/pyca/p3compat.h
@@ -10,6 +10,7 @@
 #define PyInt_FromLong      PyLong_FromLong
 #define PyString_FromString PyUnicode_FromString
 #define PyString_Check      PyUnicode_Check
+#define PyString_FromFormat PyUnicode_FromFormat
 // This should suffice, as long as we don't call this twice and try to hold onto both!
 static char *PyString_AsString(PyObject *o)
 {

--- a/pyca/p3compat.h
+++ b/pyca/p3compat.h
@@ -11,7 +11,7 @@
 #define PyString_FromString PyUnicode_FromString
 #define PyString_Check      PyUnicode_Check
 // This should suffice, as long as we don't call this twice and try to hold onto both!
-static const char *PyString_AsString(PyObject *o)
+static char *PyString_AsString(PyObject *o)
 {
     static char *result = NULL;
     if (result) {

--- a/pyca/p3compat.h
+++ b/pyca/p3compat.h
@@ -1,6 +1,5 @@
 #ifndef PYCA_P3COMPAT
 #define PYCA_P3COMPAT
-#endif
 #if PY_MAJOR_VERSION >= 3
 #define IS_PY3K
 #define DECLARE_INIT(name)  PyMODINIT_FUNC PyInit_##name(void)
@@ -53,4 +52,5 @@ static int PyString_Size(PyObject *o)
 #define INITERROR           return
 #define Py_TYPE(o)          ((o)->ob_type)
 #define PyVarObject_HEAD_INIT(type, size)   PyObject_HEAD_INIT(type) size,
+#endif
 #endif

--- a/pyca/putfunctions.hh
+++ b/pyca/putfunctions.hh
@@ -1,3 +1,4 @@
+#include "p3compat.h"
 // Channel access PUT template functions
 static inline void _pyca_put(PyObject* pyvalue, dbr_string_t* buf)
 {

--- a/pyca/pyca.cc
+++ b/pyca/pyca.cc
@@ -739,7 +739,7 @@ extern "C" {
 #else
         PyObject* module = Py_InitModule("pyca", pyca_methods);
 #endif
-        if (m == NULL) {
+        if (module == NULL) {
             INITERROR;
         }
 

--- a/pyca/pyca.cc
+++ b/pyca/pyca.cc
@@ -763,17 +763,10 @@ extern "C" {
         // secs between Jan 1st 1970 and Jan 1st 1990
         PyDict_SetItemString(d, "epoch", PyLong_FromLong(7305 * 86400));
 
-#if 1
-        a = PyCObject_FromVoidPtr((void *)pyca_getevent_handler, NULL);
+        a = PyCapsule_New((void *)pyca_getevent_handler, "pyca.get_handler", NULL);
         PyModule_AddObject(module, "get_handler", a);
-        a = PyCObject_FromVoidPtr((void *)pyca_monitor_handler, NULL);
+        a = PyCapsule_New((void *)pyca_monitor_handler, "pyca.monitor_handler", NULL);
         PyModule_AddObject(module, "monitor_handler", a);
-#else
-        a = PyCapsule_New(pyca_getevent_handler, "pyca.get_handler", NULL);
-        PyModule_AddObject(module, "get_handler", a);
-        a = PyCapsule_New(pyca_monitor_handler, "pyca.monitor_handler", NULL);
-        PyModule_AddObject(module, "monitor_handler", a);
-#endif
 
         // Add capv type to this module
         Py_INCREF(&capv_type);

--- a/pyca/pyca.cc
+++ b/pyca/pyca.cc
@@ -516,7 +516,9 @@ extern "C" {
 
     static PyTypeObject capv_type = {
         PyObject_HEAD_INIT(0)
+#ifndef IS_PY3K
         0,
+#endif
         "pyca.capv",
         sizeof(capv),
         0,

--- a/pyca/pyca.cc
+++ b/pyca/pyca.cc
@@ -765,11 +765,17 @@ extern "C" {
         // secs between Jan 1st 1970 and Jan 1st 1990
         PyDict_SetItemString(d, "epoch", PyLong_FromLong(7305 * 86400));
 
+#ifdef IS_PY3K
         a = PyCapsule_New((void *)pyca_getevent_handler, "pyca.get_handler", NULL);
         PyModule_AddObject(module, "get_handler", a);
         a = PyCapsule_New((void *)pyca_monitor_handler, "pyca.monitor_handler", NULL);
         PyModule_AddObject(module, "monitor_handler", a);
-
+#else
+        a = PyCObject_FromVoidPtr((void *)pyca_getevent_handler, NULL);
+        PyModule_AddObject(module, "get_handler", a);
+        a = PyCObject_FromVoidPtr((void *)pyca_monitor_handler, NULL);
+        PyModule_AddObject(module, "monitor_handler", a);
+#endif
         // Add capv type to this module
         Py_INCREF(&capv_type);
         PyModule_AddObject(module, "capv", (PyObject*)&capv_type);

--- a/pyca/pyca.hh
+++ b/pyca/pyca.hh
@@ -1,3 +1,4 @@
+#include "p3compat.h"
 // Structure to define a channel access PV for python
 struct capv {
   PyObject_HEAD

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ pyca = Extension('pyca',
                  library_dirs=[epics_lib],
                  libraries=['Com', 'ca'])
 
-setup(name='pyca', version='2.3.2',
+setup(name='pyca', version='3.0.0',
       description='python channel access library',
       ext_modules=[pyca], url='https://confluence.slac.stanford.edu/display/PCDS/Using+pyca',
       author='Amedeo Perazzo', author_email='amedeo@slac.stanford.edu')

--- a/test-conda.sh
+++ b/test-conda.sh
@@ -1,2 +1,2 @@
 mkdir -p conda-bld-tst
-conda build conda-recipe --output-folder conda-bld-tst --python 2.7 --numpy 1.13
+conda build conda-recipe --output-folder conda-bld-tst --python 3.6 --numpy 1.13

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -1,3 +1,4 @@
+rm -rf build
 python setup.py build
 LIB=`find build -name pyca*.so`
 LINK='pyca.so'

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -1,7 +1,9 @@
 python setup.py build
 LIB=`find build -name pyca.so`
 LINK='pyca.so'
-rm $LINK
+if [ -L $LINK ]; then
+  rm $LINK
+fi
 if [ -z $LIB ]; then
   exit
 fi

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -1,5 +1,5 @@
 python setup.py build
-LIB=`find build -name pyca.so`
+LIB=`find build -name pyca*.so`
 LINK='pyca.so'
 if [ -L $LINK ]; then
   rm $LINK

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -1,6 +1,8 @@
-mkdir -p setup-py-tst
 python setup.py build
 LIB=`find build -name pyca.so`
-LINK='setup-py-tst/pyca.so'
+LINK='pyca.so'
 rm $LINK
+if [ -z $LIB ]; then
+  exit
+fi
 ln -s $LIB $LINK

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -1,3 +1,4 @@
+import sys
 import time
 import threading
 import logging
@@ -5,6 +6,9 @@ import pytest
 import numpy as np
 import pyca
 from conftest import test_pvs, setup_pv, pvbase
+
+if sys.version_info.major >= 3:
+    long = int
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
PyCA will build and pass all included tests in a Python 3 environment after this PR. Backwards-compatibility was retained with Python 2 but this will be removed in a later release, as soon as it becomes infeasible to maintain both versions. This was achieved largely by reusing Mike's solution for extending the DAQ interface libraries to support both versions of Python.

All testing was done with Python 2.7 or 3.6, numpy 1.13, epics 3.14.12.6, and pcaspy 0.7.0