### PR TITLE
Updated include_dirs to work for EPICS BASE >= 3.15 and added rpaths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,21 +4,27 @@ import numpy as np
 
 if sys.platform == 'darwin':
     libsrc = 'Darwin'
+    compiler = 'clang'
 elif sys.platform.startswith('linux'):
     libsrc = 'Linux'
+    compiler = 'gcc'
 else:
     libsrc = None
 
 epics_inc = os.getenv("EPICS_BASE") + "/include"
 epics_lib = os.getenv("EPICS_BASE") + "/lib/" + os.getenv("EPICS_HOST_ARCH")
 numpy_inc = np.get_include()
+numpy_lib = np.__path__[0]
 
 pyca = Extension('pyca',
                  language='c++',
                  sources=['pyca/pyca.cc'],
-                 include_dirs=['pyca', epics_inc, epics_inc + '/os/' + libsrc,
-                               numpy_inc],
-                 library_dirs=[epics_lib],
+                 include_dirs=['pyca', epics_inc,
+                                epics_inc + '/os/' + libsrc,
+                                epics_inc + '/os/compiler/' + compiler,
+                                numpy_inc],
+                 library_dirs=[epics_lib,numpy_lib],
+                 runtime_library_dirs=[epics_lib,numpy_lib],
                  libraries=['Com', 'ca'])
 
 setup(name='pyca',


### PR DESCRIPTION
Added runtime_library_dirs so libs will have rpaths.
Added numpy_lib dir to library_dirs and runtime_library_dirs

Zach, can you confirm this builds for you?
I'd like to get a new release w/ rpath support so Patrick Pascual can deploy in Accel.