### PR TITLE
TST: Fix tests segfault

### DIFF
--- a/test/test_psp.py
+++ b/test/test_psp.py
@@ -20,13 +20,9 @@ def setup_pv(pvname, connect=True):
     return pv
 
 
-def test_server_start(server):
-    pass
-
-
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_connect_and_disconnect(pvname):
+def test_connect_and_disconnect(server, pvname):
     logger.debug('test_create_and_clear_channel %s', pvname)
     pv = setup_pv(pvname)
     assert pv.isconnected
@@ -35,7 +31,7 @@ def test_connect_and_disconnect(pvname):
 
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_get(pvname):
+def test_get(server, pvname):
     logger.debug('test_get_data %s', pvname)
     pv = setup_pv(pvname)
     value = pv.get()
@@ -45,7 +41,7 @@ def test_get(pvname):
 
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_put_get(pvname):
+def test_put_get(server, pvname):
     logger.debug('test_put_get %s', pvname)
     pv = setup_pv(pvname)
     old_value = pv.get()
@@ -65,7 +61,7 @@ def test_put_get(pvname):
 
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_monitor(pvname):
+def test_monitor(server, pvname):
     logger.debug('test_subscribe %s', pvname)
     pv = setup_pv(pvname)
     old_value = pv.get()
@@ -90,7 +86,7 @@ def test_monitor(pvname):
 
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_misc(pvname):
+def test_misc(server, pvname):
     logger.debug('test_misc %s', pvname)
     pv = setup_pv(pvname)
     assert isinstance(pv.host(), str)
@@ -102,7 +98,7 @@ def test_misc(pvname):
 
 
 @pytest.mark.timeout(10)
-def test_waveform():
+def test_waveform(server):
     logger.debug('test_waveform')
     pv = setup_pv(pvbase + ":WAVE")
     # Do as a tuple
@@ -119,7 +115,7 @@ def test_waveform():
 
 
 @pytest.mark.timeout(10)
-def test_threads():
+def test_threads(server):
     logger.debug('test_threads')
 
     def some_thread_thing(pvname):

--- a/test/test_psp.py
+++ b/test/test_psp.py
@@ -40,6 +40,7 @@ def test_get(pvname):
     pv = setup_pv(pvname)
     value = pv.get()
     assert value is not None
+    pv.disconnect()
 
 
 @pytest.mark.timeout(10)
@@ -59,6 +60,7 @@ def test_put_get(pvname):
     logger.debug('caput %s %s', pvname, new_value)
     pv.put(new_value, timeout=1.0)
     assert pv.get() == new_value
+    pv.disconnect()
 
 
 @pytest.mark.timeout(10)
@@ -83,6 +85,7 @@ def test_monitor(pvname):
         time.sleep(0.1)
         n += 1
     assert pv.value == new_value
+    pv.disconnect()
 
 
 @pytest.mark.timeout(10)
@@ -95,6 +98,7 @@ def test_misc(pvname):
     assert isinstance(pv.count, int)
     assert isinstance(pv.type(), str)
     assert isinstance(pv.rwaccess(), int)
+    pv.disconnect()
 
 
 @pytest.mark.timeout(10)
@@ -111,6 +115,7 @@ def test_waveform():
     val = pv.get()
     assert isinstance(val, np.ndarray)
     assert len(val) == pv.count
+    pv.disconnect()
 
 
 @pytest.mark.timeout(10)
@@ -122,6 +127,7 @@ def test_threads():
         pv = setup_pv(pvname)
         val = pv.get()
         assert isinstance(val, tuple)
+        pv.disconnect()
 
     pvname = pvbase + ":WAVE"
     thread = threading.Thread(target=some_thread_thing, args=(pvname,))

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -124,6 +124,7 @@ def test_get_data(pvname):
         assert key in pv.data
     # check that value is not None
     assert pv.data['value'] is not None
+    pv.clear_channel()
 
 
 @pytest.mark.timeout(10)
@@ -151,6 +152,7 @@ def test_put_get(pvname):
     assert pv.getevt_cb.wait(timeout=1)
     recv_value = pv.data['value']
     assert recv_value == new_value
+    pv.clear_channel()
 
 
 @pytest.mark.timeout(10)
@@ -186,6 +188,7 @@ def test_subscribe(pvname):
     assert ev.wait(timeout=1)
     recv_value = pv.data['value']
     assert recv_value == new_value
+    pv.clear_channel()
 
 
 @pytest.mark.timeout(10)
@@ -198,6 +201,7 @@ def test_misc(pvname):
     assert isinstance(pv.count(), int)
     assert isinstance(pv.type(), str)
     assert isinstance(pv.rwaccess(), int)
+    pv.clear_channel()
 
 
 @pytest.mark.timeout(10)
@@ -221,6 +225,7 @@ def test_waveform():
     val = pv.data['value']
     assert isinstance(val, np.ndarray)
     assert len(val) == pv.count()
+    pv.clear_channel()
 
 
 @pytest.mark.timeout(10)
@@ -234,6 +239,7 @@ def test_threads():
         pyca.flush_io()
         assert pv.getevt_cb.wait(timeout=1)
         assert isinstance(pv.data['value'], tuple)
+        pv.clear_channel()
 
     pvname = pvbase + ":WAVE"
     thread = threading.Thread(target=some_thread_thing, args=(pvname,))

--- a/test/test_pyca.py
+++ b/test/test_pyca.py
@@ -87,13 +87,9 @@ def setup_pv(pvname, connect=True):
     return pv
 
 
-def test_server_start(server):
-    pass
-
-
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_create_and_clear_channel(pvname):
+def test_create_and_clear_channel(server, pvname):
     logger.debug('test_create_and_clear_channel %s', pvname)
     pv = setup_pv(pvname)
     assert pv.connect_cb.connected
@@ -106,7 +102,7 @@ def test_create_and_clear_channel(pvname):
 
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_get_data(pvname):
+def test_get_data(server, pvname):
     logger.debug('test_get_data %s', pvname)
     pv = setup_pv(pvname)
     # get time vars
@@ -129,7 +125,7 @@ def test_get_data(pvname):
 
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_put_get(pvname):
+def test_put_get(server, pvname):
     logger.debug('test_put_get %s', pvname)
     pv = setup_pv(pvname)
     pv.get_data(False, -1.0)
@@ -157,7 +153,7 @@ def test_put_get(pvname):
 
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_subscribe(pvname):
+def test_subscribe(server, pvname):
     logger.debug('test_subscribe %s', pvname)
     pv = setup_pv(pvname)
     ev = threading.Event()
@@ -193,7 +189,7 @@ def test_subscribe(pvname):
 
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('pvname', test_pvs)
-def test_misc(pvname):
+def test_misc(server, pvname):
     logger.debug('test_misc %s', pvname)
     pv = setup_pv(pvname)
     assert isinstance(pv.host(), str)
@@ -205,7 +201,7 @@ def test_misc(pvname):
 
 
 @pytest.mark.timeout(10)
-def test_waveform():
+def test_waveform(server):
     logger.debug('test_waveform')
     pv = setup_pv(pvbase + ":WAVE")
     # Do as a tuple
@@ -229,7 +225,7 @@ def test_waveform():
 
 
 @pytest.mark.timeout(10)
-def test_threads():
+def test_threads(server):
     logger.debug('test_threads')
 
     def some_thread_thing(pvname):


### PR DESCRIPTION
There are no functional code changes in this PR.

This is a long overdue fix of a small but annoying bug in the test suite. By properly cleaning up our tests we ensure that the test suite does not crash when it succeeds. I believe this is ignoring the root cause of the bug (something else about the test suite), but the fix is quick and suits my needs.

I ran into this issue when running full-environment integration tests where I run each test suite from all SLAC-made libraries that I'm using in my conda environment. It's hard to automatically verify that the environment is working correctly if the automatic tests unceremoniously crash at the end, so I thought I'd fix the issue here and push out a bugfix release.