### PR TITLE
Fix deadlocks and improve no-timeout get() calls.

### DIFF
--- a/psp/Pv.py
+++ b/psp/Pv.py
@@ -590,8 +590,11 @@ class Pv(pyca.capv):
                                      'of {:}'.format(self.value, self.name))
             else:
                 return str(self.value)
-
-        return self.value
+        try:
+            return self.value
+        except KeyError:
+            # If timeout=None, there's a chance that self.value isn't populated yet.
+            return None
 
     def put(self, value, timeout=DEFAULT_TIMEOUT, **kw):
         """

--- a/psp/Pv.py
+++ b/psp/Pv.py
@@ -436,7 +436,7 @@ class Pv(pyca.capv):
         self.isconnected = False
 
     def monitor(self, mask=pyca.DBE_VALUE | pyca.DBE_LOG | pyca.DBE_ALARM,
-                ctrl=None, count=None):
+                ctrl=None, count=None, wait_for_init=True):
         """
         Subscribe to monitor events from the PV channel
 
@@ -458,6 +458,11 @@ class Pv(pyca.capv):
         count : int, optional
             Subsection of waveform record to monitor. By default,
             :attr:`.count` is used
+         
+         wait_for_init : bool, optional
+            Whether to wait for an initial value to arrive for the PV before
+            returning.  If False, the PV's value and metadata might not be
+            populated when this function returns.  Defaults to True.
 
         See Also
         --------
@@ -485,10 +490,11 @@ class Pv(pyca.capv):
         #
         # The purpose of this step is to initialize the .value when we call
         # .monitor() in an interactive session.
-        try:
-            self.get()
-        except pyca.caexc:
-            pass
+        if wait_for_init:
+           try:
+               self.get()
+           except pyca.caexc:
+               pass
 
         self.ismonitored = True
 

--- a/psp/Pv.py
+++ b/psp/Pv.py
@@ -596,7 +596,6 @@ class Pv(pyca.capv):
                                      'of {:}'.format(self.value, self.name))
             else:
                 return str(self.value)
-            
         return self.value
 
     def put(self, value, timeout=DEFAULT_TIMEOUT, **kw):

--- a/psp/Pv.py
+++ b/psp/Pv.py
@@ -459,7 +459,7 @@ class Pv(pyca.capv):
             Subsection of waveform record to monitor. By default,
             :attr:`.count` is used
          
-         wait_for_init : bool, optional
+        wait_for_init : bool, optional
             Whether to wait for an initial value to arrive for the PV before
             returning.  If False, the PV's value and metadata might not be
             populated when this function returns.  Defaults to True.

--- a/psp/Pv.py
+++ b/psp/Pv.py
@@ -531,7 +531,9 @@ class Pv(pyca.capv):
             Whether to get the control form information
 
         timeout : float or None, optional
-            Time to wait for data to be returned. If None, no timeout is used
+            Time to wait for data to be returned. If None, no timeout is used.
+            If timeout is None, this method may return None if the PV's
+            value has not arrived yet.
 
         as_string : bool , optional
             Return the value as a string type. For Enum PVs, the default
@@ -580,6 +582,10 @@ class Pv(pyca.capv):
         if tmo > 0 and DEBUG != 0:
             logprint("got %s\n" % self.value.__str__())
 
+        if "value" not in self.data:
+            # If the timeout was None, there's a chance that the value hasn't arrived yet.
+            return None
+
         if as_string:
             if self.type() == 'DBF_ENUM':
                 enums = self.get_enum_set(timeout=tmo)
@@ -590,11 +596,8 @@ class Pv(pyca.capv):
                                      'of {:}'.format(self.value, self.name))
             else:
                 return str(self.value)
-        try:
-            return self.value
-        except KeyError:
-            # If timeout=None, there's a chance that self.value isn't populated yet.
-            return None
+            
+        return self.value
 
     def put(self, value, timeout=DEFAULT_TIMEOUT, **kw):
         """

--- a/pyca/pyca.cc
+++ b/pyca/pyca.cc
@@ -43,12 +43,13 @@ extern "C" {
     static PyObject* clear_channel(PyObject* self, PyObject*)
     {
         capv* pv = reinterpret_cast<capv*>(self);
-
         chid cid = pv->cid;
         if (!cid) {
             pyca_raise_pyexc_pv("clear_channel", "channel is null", pv);
         }
+        PyThreadState *state = PyEval_SaveThread();
         int result = ca_clear_channel(cid);
+        PyEval_RestoreThread(state);
         if (result != ECA_NORMAL) {
             pyca_raise_caexc_pv("ca_clear_channel", result, pv);
         }
@@ -124,7 +125,7 @@ extern "C" {
             pv->didmon = 0;
             Py_RETURN_NONE;
         }
-
+        PyThreadState *state = PyEval_SaveThread();
         evid eid = pv->eid;
         if (eid) {
             int result = ca_clear_subscription(eid);
@@ -133,6 +134,7 @@ extern "C" {
             }
             pv->eid = 0;
         }
+        PyEval_RestoreThread(state);
         Py_RETURN_NONE;
     }
 


### PR DESCRIPTION
This PR fixes two totally separate issues (sorry).

1. `capv.unsubscribe_channel()` and `capv.clear_channel()` could cause deadlocks if called while a monitor callback is in use, due to interactions with the GIL from callback threads (see https://epics.anl.gov/base/R7-0/4-docs/CAref.html#ca_clear_channel).  I fixed this by releasing the GIL before calling `ca_clear_channel()` or `ca_clear_subscription()`.  I believe this is reasonable, and it works in my testing, but I have to admit that I'm not 100% sure this is always a safe thing to do.
2. When calling `Pv.get(timeout=None)`, you were almost guaranteed to crash because the value usually won't be available by the time the method returns.  I added a check for that, and the method now returns `None` if the value isn't ready yet.  This makes `Pv.get(timeout=None)` much more useful if you want to get very large numbers of PVs at once:  You can call it in a loop, expect to get back none, then collect all the values in a second pass.

This is my totally unofficial contribution to the EPICS 2022 Codeathon :)