### PR TITLE
BLD: change the distribution name to pyca_epics, to avoid conflicts on PyPi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [ "Development Status :: 2 - Pre-Alpha", "Natural Language :: Engl
 description = "python channel access library"
 dynamic = [ "version", "readme", "dependencies", "optional-dependencies",]
 keywords = []
-name = "pyca"
+name = "pyca_epics"
 requires-python = ">=3.9"
 [[project.authors]]
 name = "SLAC National Accelerator Laboratory"


### PR DESCRIPTION
We're looking to finally host this project on pypi, and need a name that does not conflict.

pyca-epics didn't seem to offend anyone, and the imported name is still `pyca` and `psp`