### PR TITLE
BLD: do not fail fast on build_wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,6 +14,7 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14]
 


### PR DESCRIPTION
I went and uploaded `pyca_epics` to `test_pypi`, and was able to install it from the wheel (for macos).  The ubuntu/linux wheels didn't run because the build matrix was set to `fail_fast=True`


On my mac
```bash
(py312)roberttk@PC100147:~$ pip install pyca_epics --index-url https://test.pypi.org/simple/ --no-deps
Looking in indexes: https://test.pypi.org/simple/
Collecting pyca_epics
  Downloading https://test-files.pythonhosted.org/packages/d1/2c/1efff5c4b17e53cd339290b3f350ab6f5529fcc9f704fceceea24177ea44/pyca_epics-3.3.2-cp312-cp312-macosx_11_0_arm64.whl.metadata (3.8 kB)
Downloading https://test-files.pythonhosted.org/packages/d1/2c/1efff5c4b17e53cd339290b3f350ab6f5529fcc9f704fceceea24177ea44/pyca_epics-3.3.2-cp312-cp312-macosx_11_0_arm64.whl (698 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 698.7/698.7 kB 11.3 MB/s eta 0:00:00
Installing collected packages: pyca_epics
Successfully installed pyca_epics-3.3.2

(py312)roberttk@PC100147:~$ python -c "import pyca; print(pyca.__file__)"
/Users/roberttk/miniconda3/envs/py312/lib/python3.12/site-packages/pyca.cpython-312-darwin.so
```